### PR TITLE
Bump SDK and use Guzzle as default HTTP Client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "joelbutcher/facebook-graph-sdk": "^6.0.0",
-        "symfony/http-client": "^5.3|^6.0|^7.0"
+        "joelbutcher/facebook-graph-sdk": "^6.1.2"
     },
     "require-dev": {
         "mockery/mockery": "^1.4.2",

--- a/src/FacebookServiceProvider.php
+++ b/src/FacebookServiceProvider.php
@@ -5,9 +5,10 @@ namespace JoelButcher\Facebook;
 use Facebook\PersistentData\PersistentDataInterface;
 use Facebook\Url\UrlDetectionHandler;
 use Facebook\Url\UrlDetectionInterface;
-use Http\Client\HttpClient;
+use GuzzleHttp\Client;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
+use Psr\Http\Client\ClientInterface;
 
 class FacebookServiceProvider extends ServiceProvider
 {
@@ -76,8 +77,8 @@ class FacebookServiceProvider extends ServiceProvider
      */
     protected function registerDefaultHttpClient(): void
     {
-        $this->app->singleton(HttpClient::class, function () {
-            return null;
+        $this->app->singleton(ClientInterface::class, function () {
+            return new Client();
         });
     }
 
@@ -125,7 +126,7 @@ class FacebookServiceProvider extends ServiceProvider
                 'default_graph_version' => $app['config']->get('facebook.graph_version'),
                 'enable_beta_mode' => $app['config']->get('facebook.beta_mode'),
                 'persistent_data_handler' => $app[PersistentDataInterface::class],
-                'http_client' => $app[HttpClient::class],
+                'http_client' => $app[ClientInterface::class],
                 'url_detection_handler' => $app[UrlDetectionInterface::class],
             ]);
         });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace JoelButcher\Facebook\Tests;
 
 use JoelButcher\Facebook\Facebook;
 use JoelButcher\Facebook\FacebookServiceProvider;
+use Psr\Http\Client\ClientInterface;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
@@ -23,6 +24,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             'app_secret' => $this->app['config']->get('facebook.app_secret'),
             'redirect_uri' => $this->app['config']->get('facebook.redirect_uri'),
             'default_graph_version' => $this->app['config']->get('facebook.graph_version'),
+            'http_client' => $this->app[ClientInterface::class]
         ];
     }
 


### PR DESCRIPTION
This PR:
- Bumps the minimum SDK version from ^6.0.0 to ^6.1.2 to address some new changes in the SDK
- Drops `symfony/http-client` as a dependency:
  - The SDK no longer expects an instance of `Http\Client\HttpClient` and instead checks for an instance of `Psr\Http\Client\ClientInterface` (the former is deprecated and no longer included in the SDK as a dependency)
- Updates the default HTTP Client in the service provider to Guzzle, which is shipped with Laravel