### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ $ ./vendor/bin/phpunit
 
 ## Running PHP Code Sniffer
 
-You can install [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer) globally with composer.
+You can install [PHP Code Sniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) globally with composer.
 
 ``` bash
 $ composer global require squizlabs/php_codesniffer


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PHP Code Sniffer repository reference in contribution guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->